### PR TITLE
Enable yarn support

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginEngineSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginEngineSpec.groovy
@@ -1,0 +1,93 @@
+package wooga.gradle.node
+
+import org.ajoberstar.grgit.Grgit
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import spock.lang.Shared
+import spock.lang.Unroll
+
+class NodeReleasePluginEngineSpec extends GithubIntegrationSpec {
+
+    @Shared
+    def version = "1.0.0"
+
+    @Shared
+    def npmUser = System.getenv("NODE_RELEASE_NPM_USER_TEST")
+
+    @Shared
+    def npmPass = System.getenv("NODE_RELEASE_NPM_PASS_TEST")
+
+    @Shared
+    def npmAuthUrl = System.getenv("NODE_RELEASE_NPM_AUTH_URL_TEST")
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    Grgit git
+
+    @Shared
+    File packageJsonFile
+
+    def setup() {
+
+        environmentVariables.set("GRGIT_USER", testUserName)
+        environmentVariables.set("GRGIT_PASS", testUserToken)
+        environmentVariables.set('NODE_RELEASE_NPM_USER', npmUser)
+        environmentVariables.set('NODE_RELEASE_NPM_PASS', npmPass)
+        environmentVariables.set('NODE_RELEASE_NPM_AUTH_URL', npmAuthUrl)
+
+        new File(projectDir, '.gitignore') << """
+        userHome/
+        .gradle
+        .gradle-test-kit
+        .npmrc
+        """.stripIndent()
+
+        buildFile << """
+            group = 'test'
+            version = "$version"
+            ${applyPlugin(NodeReleasePlugin)}    
+            node.version = '10.5.0'
+            node.download = true
+        """.stripIndent()
+
+        packageJsonFile = createFile('package.json')
+        packageJsonFile.text = packageJsonContent([
+                "scripts"        : ["clean": "shx echo \"clean\"", "test": "shx echo \"test\"", "build": "shx echo \"build\""],
+                "devDependencies": ["shx": "^0.3.2"],
+        ])
+
+        git = Grgit.init(dir: projectDir)
+        git.add(patterns: ['.gitignore'])
+        git.commit(message: 'initial commit')
+    }
+
+    @Unroll
+    def "detect engine #engine"() {
+
+        given:
+        "a lock file of type ${lockfile}"
+        if (lockfile) {
+            createFile(lockfile)
+        }
+
+        //and: "dependencies are installed"
+        //runTasksSuccessfully('npmSetup')
+
+        when:
+        "run task ${task}"
+        def result = runTasks(task)
+
+        println(result)
+
+        then:
+        "successfully executed task ${expectedTask}"
+        result.wasExecuted(expectedTask)
+
+        where:
+        engine | task             | expectedTask     | lockfile
+        "npm"  | "node_run_clean" | "npm_run_clean"  | null
+        "npm"  | "node_run_clean" | "npm_run_clean"  | "package-lock.json"
+        "yarn" | "node_run_clean" | "yarn_run_clean" | "yarn.lock"
+    }
+}

--- a/src/test/groovy/wooga/gradle/node/NodeReleasePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/node/NodeReleasePluginSpec.groovy
@@ -45,11 +45,23 @@ class NodeReleasePluginSpec extends ProjectSpec {
 
         when:
         project.plugins.apply(NodeReleasePlugin)
-
+        
         then:
         project.tasks.getByName(taskName)
 
         where:
         taskName << [NodeReleasePlugin.NPM_TEST_TASK, NodeReleasePlugin.NPM_BUILD_TASK, NodeReleasePlugin.NPM_CLEAN_TASK]
+    }
+
+    def "set default engine to npm"() {
+        given:
+        !project.file('package-lock.json')
+        !project.file('yarn.lock')
+
+        when:
+        project.plugins.apply(NodeReleasePlugin)
+
+        then:
+        project.tasks.getByName('npm_run_test')
     }
 }


### PR DESCRIPTION
## Description
Auto-detect used engine (`npm`/`yarn`) in target project and map tasks to engine scoped tasks. defaults to npm if no lock file is present. Engine detection is based on lockfile (`package-lock.json`/`yarn.lock`). 

## Changes
* ![ADD] Auto-detection for engine (`npm`/`yarn`)
* ![CHANGE] Execute lifecycle task scoped to selected engine



[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
