### PR TITLE
Github Releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
     compile 'com.netflix.nebula:nebula-release-plugin:6.+'
     compile 'com.moowork.gradle:gradle-node-plugin:1.2.0'
+    compile "gradle.plugin.net.wooga.gradle:atlas-github:1.+"
     compile gradleApi()
     compile localGroovy()
 }

--- a/src/integrationTest/groovy/wooga/gradle/node/GithubIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/GithubIntegrationSpec.groovy
@@ -127,4 +127,20 @@ abstract class GithubIntegrationSpec extends IntegrationSpec {
     def cleanupSpec() {
         maybeDelete(testRepositoryName)
     }
+
+    GHRelease getRelease(String tagName) {
+        (GHRelease) testRepo.listReleases().find({ it.tagName == tagName })
+    }
+
+    GHRelease getReleaseByName(String name) {
+        (GHRelease) testRepo.listReleases().find({ it.name == name })
+    }
+
+    Boolean hasRelease(String tagName) {
+        getRelease(tagName) != null
+    }
+
+    Boolean hasReleaseByName(String name) {
+        getReleaseByName(name) != null
+    }
 }

--- a/src/integrationTest/groovy/wooga/gradle/node/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/IntegrationSpec.groovy
@@ -19,9 +19,14 @@ package wooga.gradle.node
 
 import groovy.json.JsonBuilder
 import groovy.json.StringEscapeUtils
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.ProvideSystemProperty
 
 class IntegrationSpec extends nebula.test.IntegrationSpec {
 
+    @Rule
+    ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
+    
     def escapedPath(String path) {
         String osName = System.getProperty("os.name").toLowerCase()
         if (osName.contains("windows")) {

--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
@@ -26,6 +26,7 @@ import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Shared
 import spock.lang.Unroll
+import wooga.gradle.github.publish.GithubPublishPlugin
 
 class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
 
@@ -75,6 +76,7 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
     Grgit git
 
     def setup() {
+
         environmentVariables.set("GRGIT_USER", testUserName)
         environmentVariables.set("GRGIT_PASS", testUserToken)
 
@@ -91,6 +93,8 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
             ${applyPlugin(NodeReleasePlugin)}    
             node.version = '10.5.0'
             node.download = true
+            
+            github.repositoryName = '$testRepositoryName'
         """.stripIndent()
 
         packageJsonFile = createFile("package.json")
@@ -111,6 +115,8 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
         git.commit(message: 'initial commit')
         git.tag.add(name: 'v0.0.1')
         git.remote.add(name: "origin", url: "https://github.com/${testRepositoryName}.git")
+
+        cleanupArtifactory(artifactoryRepoName, packageNameForPackageJson())
     }
 
     def cleanup() {
@@ -175,5 +181,43 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
         "snapshot"  | "0.1.0-SNAPSHOT"
         "candidate" | "0.1.0-rc.1"
         "final"     | "0.1.0"
+    }
+
+    @Unroll
+    def 'builds and and create #task #version with github release #released'() {
+        given: "the future npm artifact"
+        packageJsonFile.exists()
+
+        and: "some content to publish"
+        def content = createFile("content.json")
+        content.text = "hello world"
+
+        and:
+        git.add(patterns: ['.'])
+        git.commit(message: 'add files')
+
+        when: "run the publish task"
+        def result = runTasks(task)
+
+        then:
+        result.success
+        result.wasExecuted("node_publish")
+        result.wasExecuted("npm_publish")
+
+        then:
+        result.wasSkipped("nodeGithubRelease") == !released
+        hasReleaseByName(version) == released
+        print testRepo.listReleases()
+
+        if (released) {
+            def release = getReleaseByName(version)
+            release.name == version
+        }
+
+        where:
+        task        | version          | released
+        "snapshot"  | "0.1.0-SNAPSHOT" | false
+        "candidate" | "0.1.0-rc.1"     | true
+        "final"     | "0.1.0"          | true
     }
 }

--- a/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
@@ -24,6 +24,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import wooga.gradle.github.publish.GithubPublishPlugin
+import wooga.gradle.github.publish.tasks.GithubPublish
 import wooga.gradle.node.tasks.ModifyPackageJsonTask
 import wooga.gradle.node.tasks.NpmCredentialsTask
 
@@ -34,10 +36,11 @@ enum Engine {
 
 class NodeReleasePlugin implements Plugin<Project> {
 
-    static final String NPM_CLEAN_TASK = 'node_run_clean'
-    static final String NPM_BUILD_TASK = 'node_run_build'
-    static final String NPM_TEST_TASK = 'node_run_test'
-    static final String NPM_PUBLISH_TASK = 'node_publish'
+    static final String NODE_CLEAN_TASK = 'node_run_clean'
+    static final String NODE_BUILD_TASK = 'node_run_build'
+    static final String NODE_TEST_TASK = 'node_run_test'
+    static final String NODE_PUBLISH_TASK = 'node_publish'
+    static final String GITHUB_RELEASE_TASK = 'nodeGithubRelease'
 
     static final String MODIFY_PACKAGE_VERSION_TASK = 'modifyPackageJson_version'
     static final String CREATE_CREDENTIALS_TASK = 'ensureNpmrc'
@@ -63,6 +66,7 @@ class NodeReleasePlugin implements Plugin<Project> {
 
         project.pluginManager.apply(BasePlugin.class)
         project.pluginManager.apply(NodePlugin.class)
+        project.pluginManager.apply(GithubPublishPlugin.class)
 
         extension = createExtension(project)
 
@@ -72,6 +76,7 @@ class NodeReleasePlugin implements Plugin<Project> {
             configureReleaseLifecycle(project)
             configureModifyPackageJsonVersionTask(project)
             configureNpmCredentialsTasks(project, extension)
+            configureGithubPublish(project)
         }
 
         project.tasks.create(MODIFY_PACKAGE_VERSION_TASK, ModifyPackageJsonTask.class)
@@ -111,17 +116,18 @@ class NodeReleasePlugin implements Plugin<Project> {
         def cleanTask = tasks.getByName(BasePlugin.CLEAN_TASK_NAME)
         def postReleaseTask = tasks.getByName(ReleasePlugin.POST_RELEASE_TASK_NAME)
         def releaseTask = tasks.getByName('release')
-        def publishTask = project.tasks.getByName(engineScopedTaskName(NPM_PUBLISH_TASK))
+        def publishTask = project.tasks.getByName(engineScopedTaskName(NODE_PUBLISH_TASK))
+        def githubPublishTask = project.tasks.create(name:GITHUB_RELEASE_TASK, type:GithubPublish)
 
-        def nodeCleanTask = tasks.create(NPM_CLEAN_TASK)
-        def nodeTestTask = tasks.create(NPM_TEST_TASK)
-        def nodeBuildTask = tasks.create(NPM_BUILD_TASK)
-        def nodePublishTask = tasks.create(NPM_PUBLISH_TASK)
+        def nodeCleanTask = tasks.create(NODE_CLEAN_TASK)
+        def nodeTestTask = tasks.create(NODE_TEST_TASK)
+        def nodeBuildTask = tasks.create(NODE_BUILD_TASK)
+        def nodePublishTask = tasks.create(NODE_PUBLISH_TASK)
 
-        def engineScopedCleanTask = tasks.getByName(engineScopedTaskName(NPM_CLEAN_TASK))
-        def engineScopedTestTask = tasks.getByName(engineScopedTaskName(NPM_TEST_TASK))
-        def engineScopedBuildTask = tasks.getByName(engineScopedTaskName(NPM_BUILD_TASK))
-        def engineScopedPublishTask = tasks.getByName(engineScopedTaskName(NPM_PUBLISH_TASK))
+        def engineScopedCleanTask = tasks.getByName(engineScopedTaskName(NODE_CLEAN_TASK))
+        def engineScopedTestTask = tasks.getByName(engineScopedTaskName(NODE_TEST_TASK))
+        def engineScopedBuildTask = tasks.getByName(engineScopedTaskName(NODE_BUILD_TASK))
+        def engineScopedPublishTask = tasks.getByName(engineScopedTaskName(NODE_PUBLISH_TASK))
 
         nodeCleanTask.dependsOn engineScopedCleanTask
         nodeTestTask.dependsOn engineScopedTestTask
@@ -133,12 +139,13 @@ class NodeReleasePlugin implements Plugin<Project> {
         releaseTask.dependsOn assembleTask
         assembleTask.dependsOn nodeBuildTask
         tasks.release.dependsOn assembleTask
-        postReleaseTask.dependsOn nodePublishTask
+        postReleaseTask.dependsOn nodePublishTask, githubPublishTask
         publishTask.mustRunAfter releaseTask
+        githubPublishTask.mustRunAfter nodePublishTask
     }
 
     private static void configureModifyPackageJsonVersionTask(Project project) {
-        def publishTask = project.tasks.getByName(NPM_PUBLISH_TASK)
+        def publishTask = project.tasks.getByName(NODE_PUBLISH_TASK)
         project.tasks.withType(ModifyPackageJsonTask, new Action<ModifyPackageJsonTask>() {
 
             @Override
@@ -164,6 +171,24 @@ class NodeReleasePlugin implements Plugin<Project> {
                 npmCredentialsTask.npmPass.set(extension.npmPass)
                 npmCredentialsTask.npmAuthUrl.set(extension.npmAuthUrl)
                 npmCredentialsTask.npmrcFile.set(extension.npmrcFile)
+            }
+        })
+    }
+
+    private static void configureGithubPublish(Project project) {
+        project.tasks.withType(GithubPublish, new Action<GithubPublish>() {
+
+            @Override
+            void execute(GithubPublish githubPublishTask) {
+                githubPublishTask.group = TASK_GROUP
+                githubPublishTask.tagName = "v${project.version}"
+                githubPublishTask.releaseName = project.version
+                githubPublishTask.body = null
+                githubPublishTask.draft = false
+                githubPublishTask.prerelease = project.status != 'release'
+                githubPublishTask.onlyIf {
+                    ['candidate', 'release'].contains(project.status)
+                }
             }
         })
     }

--- a/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
@@ -40,7 +40,6 @@ class NodeReleasePlugin implements Plugin<Project> {
     static final String NODE_BUILD_TASK = 'node_run_build'
     static final String NODE_TEST_TASK = 'node_run_test'
     static final String NODE_PUBLISH_TASK = 'node_publish'
-    static final String GITHUB_RELEASE_TASK = 'nodeGithubRelease'
 
     static final String MODIFY_PACKAGE_VERSION_TASK = 'modifyPackageJson_version'
     static final String CREATE_CREDENTIALS_TASK = 'ensureNpmrc'
@@ -87,7 +86,7 @@ class NodeReleasePlugin implements Plugin<Project> {
     private static detectEngine(Project project) {
         engine = project.file(YARN_LOCK_JSON).exists() ? Engine.yarn : Engine.npm
     }
-
+    
     private static engineScopedTaskName(String taskName) {
         return "${engine}_${(taskName - "node_")}"
     }
@@ -117,7 +116,7 @@ class NodeReleasePlugin implements Plugin<Project> {
         def postReleaseTask = tasks.getByName(ReleasePlugin.POST_RELEASE_TASK_NAME)
         def releaseTask = tasks.getByName('release')
         def publishTask = project.tasks.getByName(engineScopedTaskName(NODE_PUBLISH_TASK))
-        def githubPublishTask = project.tasks.create(name:GITHUB_RELEASE_TASK, type:GithubPublish)
+        def githubPublishTask = project.tasks.getByName(GithubPublishPlugin.PUBLISH_TASK_NAME)
 
         def nodeCleanTask = tasks.create(NODE_CLEAN_TASK)
         def nodeTestTask = tasks.create(NODE_TEST_TASK)
@@ -180,7 +179,6 @@ class NodeReleasePlugin implements Plugin<Project> {
 
             @Override
             void execute(GithubPublish githubPublishTask) {
-                githubPublishTask.group = TASK_GROUP
                 githubPublishTask.tagName = "v${project.version}"
                 githubPublishTask.releaseName = project.version
                 githubPublishTask.body = null

--- a/src/test/groovy/wooga/gradle/node/NodeReleasePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/node/NodeReleasePluginSpec.groovy
@@ -20,6 +20,7 @@ package wooga.gradle.node
 import nebula.test.ProjectSpec
 import org.ajoberstar.grgit.Grgit
 import spock.lang.Unroll
+import wooga.gradle.github.publish.GithubPublishPlugin
 
 class NodeReleasePluginSpec extends ProjectSpec {
 
@@ -50,7 +51,7 @@ class NodeReleasePluginSpec extends ProjectSpec {
         project.tasks.getByName(taskName)
 
         where:
-        taskName << [NodeReleasePlugin.NPM_TEST_TASK, NodeReleasePlugin.NPM_BUILD_TASK, NodeReleasePlugin.NPM_CLEAN_TASK]
+        taskName << [NodeReleasePlugin.NODE_TEST_TASK, NodeReleasePlugin.NODE_BUILD_TASK, NodeReleasePlugin.NODE_CLEAN_TASK]
     }
 
     def "set default engine to npm"() {
@@ -63,5 +64,13 @@ class NodeReleasePluginSpec extends ProjectSpec {
 
         then:
         project.tasks.getByName('npm_run_test')
+    }
+
+    def "creates github publish task"() {
+        when:
+        project.plugins.apply(NodeReleasePlugin)
+
+        then:
+        project.tasks.getByName(GithubPublishPlugin.PUBLISH_TASK_NAME)
     }
 }

--- a/src/test/groovy/wooga/gradle/node/NodeReleasePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/node/NodeReleasePluginSpec.groovy
@@ -20,7 +20,6 @@ package wooga.gradle.node
 import nebula.test.ProjectSpec
 import org.ajoberstar.grgit.Grgit
 import spock.lang.Unroll
-import wooga.gradle.github.publish.GithubPublishPlugin
 
 class NodeReleasePluginSpec extends ProjectSpec {
 
@@ -51,7 +50,7 @@ class NodeReleasePluginSpec extends ProjectSpec {
         project.tasks.getByName(taskName)
 
         where:
-        taskName << [NodeReleasePlugin.NODE_TEST_TASK, NodeReleasePlugin.NODE_BUILD_TASK, NodeReleasePlugin.NODE_CLEAN_TASK]
+        taskName << ['node_run_test', 'node_run_build', 'node_run_clean', 'githubPublish']
     }
 
     def "set default engine to npm"() {
@@ -64,13 +63,5 @@ class NodeReleasePluginSpec extends ProjectSpec {
 
         then:
         project.tasks.getByName('npm_run_test')
-    }
-
-    def "creates github publish task"() {
-        when:
-        project.plugins.apply(NodeReleasePlugin)
-
-        then:
-        project.tasks.getByName(GithubPublishPlugin.PUBLISH_TASK_NAME)
     }
 }


### PR DESCRIPTION
## Description

Create github releases with `atlas-github` plugin in release lifecycle.
Fix for false assumption that `nebula-release-plugin` creates github releases (it only creates git tags).

### Requirements
We have to set a repository name to tell `atlas-github` where to create the release:

**build.gradle:**
```
github.repositoryName = 'wooga/repo-name'
```
## Changes
* ![ADD] `nodeGithubPublish` task of type `wooga.gradle.github.publish.tasks.GithubPublish` to lifecycle

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
