### PR TITLE
Fix `prerelease` field

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
@@ -26,7 +26,6 @@ import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Shared
 import spock.lang.Unroll
-import wooga.gradle.github.publish.GithubPublishPlugin
 
 class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
 
@@ -186,7 +185,7 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
     }
 
     @Unroll
-    def 'builds and and create #task #version with github release #expectRelease'() {
+    def 'builds and and create #task #version with github release #expectRelease as prerelease #prerelease'() {
         given: "the future npm artifact"
         packageJsonFile.exists()
 
@@ -209,10 +208,14 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
 
         hasReleaseByName(version) == expectRelease
 
+        if (expectRelease) {
+            getReleaseByName(version).prerelease == prerelease
+        }
+
         where:
-        task        | version          | expectRelease
-        "snapshot"  | "0.1.0-SNAPSHOT" | false
-        "candidate" | "0.1.0-rc.1"     | true
-        "final"     | "0.1.0"          | true
+        task        | version          | expectRelease | prerelease
+        "snapshot"  | "0.1.0-SNAPSHOT" | false         | true
+        "candidate" | "0.1.0-rc.1"     | true          | true
+        "final"     | "0.1.0"          | true          | false
     }
 }

--- a/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
@@ -86,7 +86,7 @@ class NodeReleasePlugin implements Plugin<Project> {
     private static detectEngine(Project project) {
         engine = project.file(YARN_LOCK_JSON).exists() ? Engine.yarn : Engine.npm
     }
-    
+
     private static engineScopedTaskName(String taskName) {
         return "${engine}_${(taskName - "node_")}"
     }
@@ -183,7 +183,7 @@ class NodeReleasePlugin implements Plugin<Project> {
                 githubPublishTask.releaseName = project.version
                 githubPublishTask.body = null
                 githubPublishTask.draft = false
-                githubPublishTask.prerelease = project.status != 'release'
+                githubPublishTask.prerelease = { project.status != 'release' }
                 githubPublishTask.onlyIf {
                     ['candidate', 'release'].contains(project.status)
                 }


### PR DESCRIPTION
## Description
The current implementation set field `prerelease` of  `GithubPublish` task too early. This change evaluates project status on execution time.

## Changes
* ![CHANGE] evaluate `prerelease` status on execution time


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
