### PR TITLE
Apply semver2 version strategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compile 'com.netflix.nebula:nebula-release-plugin:6.+'
     compile 'com.moowork.gradle:gradle-node-plugin:1.2.0'
     compile "gradle.plugin.net.wooga.gradle:atlas-github:1.+"
+    compile "gradle.plugin.net.wooga.gradle:atlas-release:1.+"
     compile gradleApi()
     compile localGroovy()
 }

--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
@@ -179,7 +179,7 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
 
         where:
         task        | version
-        "snapshot"  | "0.1.0-SNAPSHOT"
+        "snapshot"  | "0.1.0-master.1"
         "candidate" | "0.1.0-rc.1"
         "final"     | "0.1.0"
     }
@@ -214,7 +214,7 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
 
         where:
         task        | version          | expectRelease | prerelease
-        "snapshot"  | "0.1.0-SNAPSHOT" | false         | true
+        "snapshot"  | "0.1.0-master.1" | false         | true
         "candidate" | "0.1.0-rc.1"     | true          | true
         "final"     | "0.1.0"          | true          | false
     }

--- a/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.node
 
 import com.moowork.gradle.node.NodePlugin
 import nebula.plugin.release.ReleasePlugin
+import org.ajoberstar.gradle.git.release.base.ReleasePluginExtension
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -28,6 +29,7 @@ import wooga.gradle.github.publish.GithubPublishPlugin
 import wooga.gradle.github.publish.tasks.GithubPublish
 import wooga.gradle.node.tasks.ModifyPackageJsonTask
 import wooga.gradle.node.tasks.NpmCredentialsTask
+import wooga.gradle.release.version.semver2.VersionStrategies
 
 enum Engine {
     npm,
@@ -72,6 +74,7 @@ class NodeReleasePlugin implements Plugin<Project> {
         if (project == project.rootProject) {
             project.pluginManager.apply(ReleasePlugin.class)
             detectEngine(project)
+            configureVersionStrategy(project)
             configureReleaseLifecycle(project)
             configureModifyPackageJsonVersionTask(project)
             configureNpmCredentialsTasks(project, extension)
@@ -189,5 +192,18 @@ class NodeReleasePlugin implements Plugin<Project> {
                 }
             }
         })
+    }
+
+    private static void configureVersionStrategy(Project project) {
+        ReleasePluginExtension releaseExtension = project.extensions.findByType(ReleasePluginExtension)
+
+        releaseExtension.with {
+            releaseExtension.versionStrategy(VersionStrategies.SNAPSHOT)
+            releaseExtension.versionStrategy(VersionStrategies.DEVELOPMENT)
+            releaseExtension.versionStrategy(VersionStrategies.PRE_RELEASE)
+            releaseExtension.versionStrategy(VersionStrategies.FINAL)
+            releaseExtension.defaultVersionStrategy = VersionStrategies.DEVELOPMENT
+
+        }
     }
 }

--- a/src/test/groovy/wooga/gradle/node/NodeReleasePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/node/NodeReleasePluginSpec.groovy
@@ -64,4 +64,183 @@ class NodeReleasePluginSpec extends ProjectSpec {
         then:
         project.tasks.getByName('npm_run_test')
     }
+
+    @Unroll('verify inferred semver 2.x version from nearestNormal: #nearestNormal, nearestAny: #nearestAnyTitle, scope: #scopeTitle, stage: #stage and branch: #branchName to be #expectedVersion')
+    def "uses custom wooga application strategies v2"() {
+
+        given: "a project with specified release stage and scope"
+
+        project.ext.set('release.stage', stage)
+        project.ext.set('version.scheme', 'semver2')
+        if (scope != _) {
+            project.ext.set('release.scope', scope)
+        }
+
+        and: "a history"
+
+        if (branchName != "master") {
+            git.checkout(branch: "$branchName", startPoint: 'master', createBranch: true)
+        }
+
+        5.times {
+            git.commit(message: 'feature commit')
+        }
+
+        git.tag.add(name: "v$nearestNormal")
+
+        distance.times {
+            git.commit(message: 'fix commit')
+        }
+
+        if (nearestAny != _) {
+            git.tag.add(name: "v$nearestAny")
+            distance.times {
+                git.commit(message: 'fix commit')
+            }
+        }
+
+        when:
+        project.plugins.apply(NodeReleasePlugin)
+
+        then:
+        project.version.toString() == expectedVersion
+
+        where:
+        nearestAny        | distance | stage        | scope   | branchName      | expectedVersion
+        _                 | 1        | "ci"         | _       | "master"        | "1.1.0-master.1"
+        _                 | 2        | "ci"         | "major" | "master"        | "2.0.0-master.2"
+        _                 | 3        | "ci"         | "minor" | "master"        | "1.1.0-master.3"
+        _                 | 4        | "ci"         | "patch" | "master"        | "1.0.1-master.4"
+
+        _                 | 1        | "ci"         | _       | "develop"       | "1.1.0-develop.1"
+        _                 | 2        | "ci"         | "major" | "develop"       | "2.0.0-develop.2"
+        _                 | 3        | "ci"         | "minor" | "develop"       | "1.1.0-develop.3"
+        _                 | 4        | "ci"         | "patch" | "develop"       | "1.0.1-develop.4"
+
+        _                 | 1        | "ci"         | _       | "feature/check" | "1.1.0-branch.feature.check.1"
+        _                 | 2        | "ci"         | _       | "hotfix/check"  | "1.0.1-branch.hotfix.check.2"
+        _                 | 3        | "ci"         | _       | "fix/check"     | "1.1.0-branch.fix.check.3"
+        _                 | 4        | "ci"         | _       | "feature-check" | "1.1.0-branch.feature.check.4"
+        _                 | 5        | "ci"         | _       | "hotfix-check"  | "1.0.1-branch.hotfix.check.5"
+        _                 | 6        | "ci"         | _       | "fix-check"     | "1.1.0-branch.fix.check.6"
+        _                 | 7        | "ci"         | _       | "PR-22"         | "1.1.0-branch.pr.22.7"
+
+        _                 | 1        | "ci"         | _       | "release/1.x"   | "1.1.0-branch.release.1.x.1"
+        _                 | 2        | "ci"         | _       | "release-1.x"   | "1.1.0-branch.release.1.x.2"
+        _                 | 3        | "ci"         | _       | "release/1.0.x" | "1.0.1-branch.release.1.0.x.3"
+        _                 | 4        | "ci"         | _       | "release-1.0.x" | "1.0.1-branch.release.1.0.x.4"
+
+        _                 | 2        | "ci"         | _       | "1.x"           | "1.1.0-branch.1.x.2"
+        _                 | 4        | "ci"         | _       | "1.0.x"         | "1.0.1-branch.1.0.x.4"
+        '2.0.0-rc.2'      | 0        | "ci"         | _       | "release/2.x"   | "2.0.0-branch.release.2.x.0"
+
+        _                 | 1        | "snapshot"   | _       | "master"        | "1.1.0-master.1"
+        _                 | 2        | "snapshot"   | "major" | "master"        | "2.0.0-master.2"
+        _                 | 3        | "snapshot"   | "minor" | "master"        | "1.1.0-master.3"
+        _                 | 4        | "snapshot"   | "patch" | "master"        | "1.0.1-master.4"
+
+        _                 | 1        | "snapshot"   | _       | "develop"        | "1.1.0-develop.1"
+        _                 | 2        | "snapshot"   | "major" | "develop"        | "2.0.0-develop.2"
+        _                 | 3        | "snapshot"   | "minor" | "develop"        | "1.1.0-develop.3"
+        _                 | 4        | "snapshot"   | "patch" | "develop"        | "1.0.1-develop.4"
+
+        _                 | 1        | "snapshot"   | _       | "feature/check" | "1.1.0-branch.feature.check.1"
+        _                 | 2        | "snapshot"   | _       | "hotfix/check"  | "1.0.1-branch.hotfix.check.2"
+        _                 | 3        | "snapshot"   | _       | "fix/check"     | "1.1.0-branch.fix.check.3"
+        _                 | 4        | "snapshot"   | _       | "feature-check" | "1.1.0-branch.feature.check.4"
+        _                 | 5        | "snapshot"   | _       | "hotfix-check"  | "1.0.1-branch.hotfix.check.5"
+        _                 | 6        | "snapshot"   | _       | "fix-check"     | "1.1.0-branch.fix.check.6"
+        _                 | 7        | "snapshot"   | _       | "PR-22"         | "1.1.0-branch.pr.22.7"
+
+        _                 | 1        | "snapshot"   | _       | "release/1.x"   | "1.1.0-branch.release.1.x.1"
+        _                 | 2        | "snapshot"   | _       | "release-1.x"   | "1.1.0-branch.release.1.x.2"
+        _                 | 3        | "snapshot"   | _       | "release/1.0.x" | "1.0.1-branch.release.1.0.x.3"
+        _                 | 4        | "snapshot"   | _       | "release-1.0.x" | "1.0.1-branch.release.1.0.x.4"
+
+        _                 | 2        | "snapshot"   | _       | "1.x"           | "1.1.0-branch.1.x.2"
+        _                 | 4        | "snapshot"   | _       | "1.0.x"         | "1.0.1-branch.1.0.x.4"
+
+        _                 | 1        | "staging"    | _       | "master"        | "1.1.0-staging.1"
+        _                 | 2        | "staging"    | "major" | "master"        | "2.0.0-staging.1"
+        _                 | 3        | "staging"    | "minor" | "master"        | "1.1.0-staging.1"
+        _                 | 4        | "staging"    | "patch" | "master"        | "1.0.1-staging.1"
+
+        '1.1.0-staging.1' | 1        | "staging"    | _       | "master"        | "1.1.0-staging.2"
+        '1.1.0-staging.2' | 1        | "staging"    | _       | "master"        | "1.1.0-staging.3"
+
+        _                 | 1        | "staging"    | _       | "release/1.x"   | "1.1.0-staging.1"
+        _                 | 2        | "staging"    | _       | "release-1.x"   | "1.1.0-staging.1"
+        _                 | 3        | "staging"    | _       | "release/1.0.x" | "1.0.1-staging.1"
+        _                 | 4        | "staging"    | _       | "release-1.0.x" | "1.0.1-staging.1"
+
+        _                 | 1        | "staging"    | _       | "1.x"           | "1.1.0-staging.1"
+        _                 | 3        | "staging"    | _       | "1.0.x"         | "1.0.1-staging.1"
+
+        "1.1.0-staging.1" | 1        | "staging"    | _       | "release/1.x"   | "1.1.0-staging.2"
+        "1.1.0-staging.1" | 2        | "staging"    | _       | "release-1.x"   | "1.1.0-staging.2"
+        "1.0.1-staging.1" | 3        | "staging"    | _       | "release/1.0.x" | "1.0.1-staging.2"
+        "1.0.1-staging.1" | 4        | "staging"    | _       | "release-1.0.x" | "1.0.1-staging.2"
+
+        "1.1.0-staging.1" | 1        | "staging"    | _       | "1.x"           | "1.1.0-staging.2"
+        "1.0.1-staging.1" | 3        | "staging"    | _       | "1.0.x"         | "1.0.1-staging.2"
+
+        _                 | 1        | "rc"         | _       | "master"        | "1.1.0-rc.1"
+        _                 | 2        | "rc"         | "major" | "master"        | "2.0.0-rc.1"
+        _                 | 3        | "rc"         | "minor" | "master"        | "1.1.0-rc.1"
+        _                 | 4        | "rc"         | "patch" | "master"        | "1.0.1-rc.1"
+
+        '1.1.0-rc.1'      | 1        | "rc"         | _       | "master"        | "1.1.0-rc.2"
+        '1.1.0-rc.2'      | 1        | "rc"         | _       | "master"        | "1.1.0-rc.3"
+
+        _                 | 1        | "rc"         | _       | "release/1.x"   | "1.1.0-rc.1"
+        _                 | 2        | "rc"         | _       | "release-1.x"   | "1.1.0-rc.1"
+        _                 | 3        | "rc"         | _       | "release/1.0.x" | "1.0.1-rc.1"
+        _                 | 4        | "rc"         | _       | "release-1.0.x" | "1.0.1-rc.1"
+
+        _                 | 1        | "rc"         | _       | "1.x"           | "1.1.0-rc.1"
+        _                 | 3        | "rc"         | _       | "1.0.x"         | "1.0.1-rc.1"
+
+        "1.1.0-rc.1"      | 1        | "rc"         | _       | "release/1.x"   | "1.1.0-rc.2"
+        "1.1.0-rc.1"      | 2        | "rc"         | _       | "release-1.x"   | "1.1.0-rc.2"
+        "1.0.1-rc.1"      | 3        | "rc"         | _       | "release/1.0.x" | "1.0.1-rc.2"
+        "1.0.1-rc.1"      | 4        | "rc"         | _       | "release-1.0.x" | "1.0.1-rc.2"
+
+        "1.1.0-rc.1"      | 1        | "rc"         | _       | "1.x"           | "1.1.0-rc.2"
+        "1.0.1-rc.1"      | 3        | "rc"         | _       | "1.0.x"         | "1.0.1-rc.2"
+
+        "1.1.0-rc.1"      | 1        | "staging"    | _       | "1.x"           | "1.1.0-staging.1"
+        "1.0.1-rc.1"      | 3        | "staging"    | _       | "1.0.x"         | "1.0.1-staging.1"
+
+        _                 | 1        | "production" | _       | "master"        | "1.1.0"
+        _                 | 2        | "production" | "major" | "master"        | "2.0.0"
+        _                 | 3        | "production" | "minor" | "master"        | "1.1.0"
+        _                 | 4        | "production" | "patch" | "master"        | "1.0.1"
+
+        _                 | 1        | "production" | _       | "release/1.x"   | "1.1.0"
+        _                 | 1        | "production" | _       | "release/1.x"   | "1.1.0"
+        _                 | 2        | "production" | _       | "release-1.x"   | "1.1.0"
+        _                 | 3        | "production" | _       | "release/1.0.x" | "1.0.1"
+        _                 | 4        | "production" | _       | "release-1.0.x" | "1.0.1"
+
+        _                 | 1        | "production" | _       | "1.x"           | "1.1.0"
+        _                 | 3        | "production" | _       | "1.0.x"         | "1.0.1"
+
+        _                 | 1        | "final"      | _       | "master"        | "1.1.0"
+        _                 | 2        | "final"      | "major" | "master"        | "2.0.0"
+        _                 | 3        | "final"      | "minor" | "master"        | "1.1.0"
+        _                 | 4        | "final"      | "patch" | "master"        | "1.0.1"
+
+        _                 | 1        | "final"      | _       | "release/1.x"   | "1.1.0"
+        _                 | 1        | "final"      | _       | "release/1.x"   | "1.1.0"
+        _                 | 2        | "final"      | _       | "release-1.x"   | "1.1.0"
+        _                 | 3        | "final"      | _       | "release/1.0.x" | "1.0.1"
+        _                 | 4        | "final"      | _       | "release-1.0.x" | "1.0.1"
+
+        _                 | 1        | "final"      | _       | "1.x"           | "1.1.0"
+        _                 | 3        | "final"      | _       | "1.0.x"         | "1.0.1"
+
+        nearestNormal = '1.0.0'
+        nearestAnyTitle = (nearestAny == _) ? "unset" : nearestAny
+        scopeTitle = (scope == _) ? "unset" : scope
+    }
 }


### PR DESCRIPTION
## Description
Apply `atlas-release` plugin and use `semver2` release strategy. With the old implementation, we didn't apply build numbers for snapshot releases.

## Changes
* ![ADD] `atlas-release` VersionStrategy

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
