### PR TITLE
Update net.wooga.plugins to 1.4.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@
                                             "ATLAS_GITHUB_INTEGRATION_PASSWORD=${githubPassword}",
                                             "NODE_RELEASE_NPM_USER_TEST=${npm_test_credentials_user}",
                                             "NODE_RELEASE_NPM_PASS_TEST=${npm_test_credentials_pass}",
-                                            "NODE_RELEASE_NPM_AUTH_URL_TEST=https://wooga.jfrog.com/wooga/api/npm/atlas-node/auth/wooga"
+                                            "NODE_RELEASE_NPM_AUTH_URL_TEST=https://wooga.jfrog.io/wooga/api/npm/atlas-node/auth/wooga"
                                 ],
                                 'windows' : [
                                             "artifactoryCredentials=${artifactory_publish}",
@@ -42,7 +42,7 @@
                                             "ATLAS_GITHUB_INTEGRATION_PASSWORD=${githubPassword2}",
                                             "NODE_RELEASE_NPM_USER_TEST=${npm_test_credentials_user}",
                                             "NODE_RELEASE_NPM_PASS_TEST=${npm_test_credentials_pass}",
-                                            "NODE_RELEASE_NPM_AUTH_URL_TEST=https://wooga.jfrog.com/wooga/api/npm/atlas-node/auth/wooga"
+                                            "NODE_RELEASE_NPM_AUTH_URL_TEST=https://wooga.jfrog.io/wooga/api/npm/atlas-node/auth/wooga"
                                 ]
                             ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '1.1.0'
+    id 'net.wooga.plugins' version '1.4.0'
 }
 
 group 'net.wooga.gradle'

--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginCredentialsSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginCredentialsSpec.groovy
@@ -159,13 +159,13 @@ class NodeReleasePluginCredentialsSpec extends GithubIntegrationSpec {
 
         and:
         def registry = file('.npmrc').readLines().first()
-        registry == '@wooga:registry=https://wooga.artifactoryonline.com/wooga/api/npm/atlas-node/'
+        registry == '@wooga:registry=https://wooga.jfrog.io/wooga/api/npm/atlas-node/'
     }
 
     def "task of type NpmCredentialsTask writes .npmrc file only if registry doesn't exist already"() {
 
         def npmrcFile = file('.npmrc')
-        npmrcFile << '@wooga:registry=https://wooga.artifactoryonline.com/wooga/api/npm/atlas-node/'
+        npmrcFile << '@wooga:registry=https://wooga.jfrog.io/wooga/api/npm/atlas-node/'
 
         given: "a valid defined task"
         buildFile << """          


### PR DESCRIPTION
## Description

Because of changes for artifactory, some token invalidations and unlimited dependencies all tests broke. This patch will fix these issues.

## Changes

* ![UPDATE] `net.wooga.plugins` to `1.4.0`
* ![FIX] test npm repo path


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
