### PR TITLE
Add candidate to rc mapping

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginIntegrationSpec.groovy
@@ -1,0 +1,45 @@
+package wooga.gradle.node
+
+import spock.lang.Unroll
+
+class NodeReleasePluginIntegrationSpec extends IntegrationSpec {
+
+    def setup() {
+        buildFile << """
+            ${applyPlugin(NodeReleasePlugin)}    
+        """.stripIndent()
+    }
+
+    @Unroll
+    def "converts #propertyName property value of #candidateName to #rcName"() {
+        given: "a gradle.properties file"
+        def gradleProperties = createFile("gradle.properties", projectDir)
+        gradleProperties << "${propertyName}=${candidateName}"
+
+        when:
+        def result = runTasksSuccessfully("properties")
+
+        then:
+        result.standardOutput.contains("${propertyName}: ${rcName}")
+
+        where:
+        propertyName = "release.stage"
+        candidateName = "candidate"
+        rcName = "rc"
+    }
+
+    @Unroll
+    def "renames task name from #candidateTaskName to #rcTaskName"() {
+        when:
+        // We expect the task to fail
+        def result = runTasks(candidateTaskName)
+
+        then:
+        !result.standardOutput.contains("task ':${candidateTaskName}'")
+        result.standardOutput.contains("task ':${rcTaskName}'")
+
+        where:
+        candidateTaskName = "candidate"
+        rcTaskName = "rc"
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
@@ -18,6 +18,7 @@
 package wooga.gradle.node
 
 import groovy.json.JsonSlurper
+import nebula.test.Integration
 import org.ajoberstar.grgit.Grgit
 import org.jfrog.artifactory.client.Artifactory
 import org.jfrog.artifactory.client.ArtifactoryClientBuilder
@@ -26,6 +27,7 @@ import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Shared
 import spock.lang.Unroll
+
 
 class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
 
@@ -226,17 +228,5 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
         "snapshot" | "0.1.0-master.1" | false         | true
         "rc"       | "0.1.0-rc.1"     | true          | true
         "final"    | "0.1.0"          | true          | false
-    }
-
-    def "converts task/release.stage candidate to rc"() {
-        given: "a gradle.properties file"
-        def gradleProperties = createFile("gradle.properties", projectDir)
-        gradleProperties << "release.stage=candidate"
-
-        when:
-        def result = runTasksSuccessfully("properties")
-
-        then:
-        result.standardOutput.contains("release.stage=rc")
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
@@ -227,4 +227,16 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
         "rc"       | "0.1.0-rc.1"     | true          | true
         "final"    | "0.1.0"          | true          | false
     }
+
+    def "converts task/release.stage candidate to rc"() {
+        given: "a gradle.properties file"
+        def gradleProperties = createFile("gradle.properties", projectDir)
+        gradleProperties << "release.stage=candidate"
+
+        when:
+        def result = runTasksSuccessfully("properties")
+
+        then:
+        result.standardOutput.contains("release.stage=rc")
+    }
 }

--- a/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.BasePlugin
+import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.publish.plugins.PublishingPlugin
 import org.gradle.api.specs.Spec
 import org.gradle.language.base.plugins.LifecycleBasePlugin
@@ -33,7 +34,6 @@ import wooga.gradle.node.tasks.NpmCredentialsTask
 import wooga.gradle.version.VersionPlugin
 import wooga.gradle.version.VersionPluginExtension
 import wooga.gradle.version.VersionScheme
-
 
 class NodeReleasePlugin implements Plugin<Project> {
 
@@ -63,6 +63,7 @@ class NodeReleasePlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        aliasCandidateTasksToRc(project)
 
         project.pluginManager.apply(BasePlugin.class)
         project.pluginManager.apply(NodePlugin.class)
@@ -70,7 +71,6 @@ class NodeReleasePlugin implements Plugin<Project> {
 
         extension = createExtension(project)
 
-        aliasCandidateTasksToRc(project)
 
         if (project == project.rootProject) {
             detectEngine(project)
@@ -259,7 +259,9 @@ class NodeReleasePlugin implements Plugin<Project> {
         // Also update the release stage property for the pipeline
         if (project.properties.containsKey(releaseStagePropertyName)
                 && project.properties[releaseStagePropertyName] == "candidate") {
-            project.properties[releaseStagePropertyName] = "rc"
+            project.allprojects.each {
+                it.extensions.getByType(ExtraPropertiesExtension).set(releaseStagePropertyName, "rc")
+            }
         }
     }
 }

--- a/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
@@ -63,7 +63,6 @@ class NodeReleasePlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        aliasCandidateTasksToRc(project)
 
         project.pluginManager.apply(BasePlugin.class)
         project.pluginManager.apply(NodePlugin.class)
@@ -71,9 +70,9 @@ class NodeReleasePlugin implements Plugin<Project> {
 
         extension = createExtension(project)
 
-
         if (project == project.rootProject) {
             detectEngine(project)
+            aliasCandidateTasksToRc(project)
             applyVersionPlugin(project)
             configureReleaseLifecycle(project)
             configureModifyPackageJsonVersionTask(project)

--- a/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
@@ -238,15 +238,13 @@ class NodeReleasePlugin implements Plugin<Project> {
         return "${engine}_${(taskName - "node_")}"
     }
 
-    // TODO: Write test to make sure that release.stage property gets mapped from candidate to rc
     /**
      * Older versions of this plugin used the {@code candidate} task name for what we consider the {@code rc} task.
      * We need to replace any mentions of {@code candidate} with {@code rc} for our newer API.
      */
     protected static void aliasCandidateTasksToRc(Project project) {
 
-        println("Mapping beep boop")
-
+        // Rename the 'candidate' task, if present, to 'rc'
         List<String> cliTasks = project.rootProject.gradle.startParameter.taskNames
         if (cliTasks.contains(DEPRECATED_CANDIDATE_TASK_NAME)) {
             cliTasks.remove(DEPRECATED_CANDIDATE_TASK_NAME)
@@ -256,7 +254,7 @@ class NodeReleasePlugin implements Plugin<Project> {
 
         def releaseStagePropertyName = "release.stage"
 
-        // Also update the release stage property for the pipeline
+        // Also rename 'candidate' to 'rc' for the release stage
         if (project.properties.containsKey(releaseStagePropertyName)
                 && project.properties[releaseStagePropertyName] == "candidate") {
             project.allprojects.each {


### PR DESCRIPTION
## Description

Add "candidate" -> "rc" `releaase.stage` property mapping.

## Changes
* ![ADD] Map `release.stage` property from "candidate" to "rc" when applicable

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
