### PR TITLE
Add missing test for setting candidate stage in command line

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginIntegrationSpec.groovy
@@ -9,9 +9,23 @@ class NodeReleasePluginIntegrationSpec extends IntegrationSpec {
             ${applyPlugin(NodeReleasePlugin)}    
         """.stripIndent()
     }
+    
+    @Unroll
+    def "converts #propertyName property value of #candidateName to #rcName in command line"() {
+        when:
+        def result = runTasksSuccessfully("properties", "-P", "release.stage=${candidateName}")
+
+        then:
+        result.standardOutput.contains("${propertyName}: ${rcName}")
+
+        where:
+        propertyName = "release.stage"
+        candidateName = "candidate"
+        rcName = "rc"
+    }
 
     @Unroll
-    def "converts #propertyName property value of #candidateName to #rcName"() {
+    def "converts #propertyName property value of #candidateName to #rcName in properties file"() {
         given: "a gradle.properties file"
         def gradleProperties = createFile("gradle.properties", projectDir)
         gradleProperties << "${propertyName}=${candidateName}"


### PR DESCRIPTION
## Description

Add missing test for setting candidate stage in command line

## Changes
* ![ADD] Add missing test for setting candidate stage in command line


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
