### PR TITLE
Fix missing node build execution during publish

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
@@ -177,6 +177,7 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
         then:
         print(result.standardOutput)
         result.success
+        result.wasExecuted("node_run_build")
         result.wasExecuted("npm_publish")
         hasPackageOnArtifactory(artifactoryRepoName, packageNameForPackageJson())
         config.version == version
@@ -211,6 +212,7 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
 
         then:
         result.success
+        result.wasExecuted("node_run_build")
         result.wasExecuted("node_publish")
         result.wasExecuted("npm_publish")
         result.wasSkipped("githubPublish") != expectRelease

--- a/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
@@ -170,7 +170,7 @@ class NodeReleasePlugin implements Plugin<Project> {
         assembleTask.dependsOn nodeBuildTask
         // Set up publish lifecycle dependencies
         nodePublishTask.dependsOn engineScopedPublishTask
-        publishTask.dependsOn nodePublishTask
+        publishTask.dependsOn nodeBuildTask, nodePublishTask
         githubPublishTask.mustRunAfter nodePublishTask
 
         // TODO: Add custom tasks previously provided by the nebula release plugin


### PR DESCRIPTION
## Description

The last patch to gradle 6.9 added a small regression. The node build task was no longer executed when calling publish. During a normal snapshot phase that was done by calling `check` before.  But our pipelines don't call `check` during a publish flow so the package gets published empty.

## Changes

* ![FIX] missing `node` build execution during publish

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"