### PR TITLE
Fix order of node_build and node_publish during publish

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
@@ -177,6 +177,7 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
         then:
         print(result.standardOutput)
         result.success
+        result.standardOutput.indexOf("Task :node_run_build") < result.standardOutput.indexOf("Task :node_publish")
         result.wasExecuted("node_run_build")
         result.wasExecuted("npm_publish")
         hasPackageOnArtifactory(artifactoryRepoName, packageNameForPackageJson())
@@ -212,6 +213,7 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
 
         then:
         result.success
+        result.standardOutput.indexOf("Task :node_run_build") < result.standardOutput.indexOf("Task :node_publish")
         result.wasExecuted("node_run_build")
         result.wasExecuted("node_publish")
         result.wasExecuted("npm_publish")

--- a/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/node/NodeReleasePlugin.groovy
@@ -169,8 +169,8 @@ class NodeReleasePlugin implements Plugin<Project> {
         nodeBuildTask.dependsOn engineScopedBuildTask
         assembleTask.dependsOn nodeBuildTask
         // Set up publish lifecycle dependencies
-        nodePublishTask.dependsOn engineScopedPublishTask
-        publishTask.dependsOn nodeBuildTask, nodePublishTask
+        nodePublishTask.dependsOn nodeBuildTask, engineScopedPublishTask
+        publishTask.dependsOn nodePublishTask
         githubPublishTask.mustRunAfter nodePublishTask
 
         // TODO: Add custom tasks previously provided by the nebula release plugin


### PR DESCRIPTION
## Description

A patch to fix a second small error. The build task is now executed but run after the `node_publish` task which means the package is still empty. This patch simply forces the order.

## Changes

* ![FIX] order of `node_build` and `node_publish`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"