### PR TITLE
Add snyk integration [ATLAS-700]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,8 @@
                   usernamePassword(credentialsId: 'github_integration', passwordVariable: 'githubPassword', usernameVariable: 'githubUser'),
                   usernamePassword(credentialsId: 'github_integration_2', passwordVariable: 'githubPassword2', usernameVariable: 'githubUser2'),
                   usernamePassword(credentialsId: 'npm_test_credentials', passwordVariable: 'npm_test_credentials_pass', usernameVariable: 'npm_test_credentials_user'),
-                  string(credentialsId: 'atlas_node_release_coveralls_token', variable: 'coveralls_token')]) {
+                  string(credentialsId: 'atlas_node_release_coveralls_token', variable: 'coveralls_token'),
+                  string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN')]) {
 
      def testEnvironment = [
                                 'macos' : [

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,10 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '3.0.0-rc.2'
+    id 'net.wooga.plugins' version '3.1.0'
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-gradle-plugin" version "0.2.0"
+    id "net.wooga.cve-dependency-resolution" version "0.4.0"
 }
 
 group 'net.wooga.gradle'
@@ -31,7 +34,7 @@ repositories {
 
 dependencies {
     // TODO: Figure out how to address this once the below rejected versions finally work, they don't work when resolved to
-    testImplementation('org.jfrog.artifactory.client:artifactory-java-client-services:(2.9, 3]') {
+    testImplementation('org.jfrog.artifactory.client:artifactory-java-client-services:[2.9, 3[') {
         exclude module: 'logback-classic'
         version {
             reject("2.11.1", "2.11.0")
@@ -39,16 +42,16 @@ dependencies {
         }
     }
     testImplementation 'org.kohsuke:github-api:1.3+'
-    testImplementation 'com.wooga.gradle:gradle-commons-test:(1,2]'
+    testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2['
 
-    implementation 'org.ajoberstar.grgit:grgit-core:(4.1,5]'
-    implementation 'org.ajoberstar.grgit:grgit-gradle:(4.1,5]'
+    implementation 'org.ajoberstar.grgit:grgit-core:[4.1.1,5['
+    implementation 'org.ajoberstar.grgit:grgit-gradle:[4.1.1,5['
     implementation "com.github.node-gradle:gradle-node-plugin:3.2.1"
 
     // Internal wooga plugins
-    implementation 'com.wooga.gradle:gradle-commons:(1,2]'
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-version:1+'
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-github:(2, 3]'
+    implementation 'com.wooga.gradle:gradle-commons:[1,2['
+    implementation 'gradle.plugin.net.wooga.gradle:atlas-version:[1,2['
+    implementation 'gradle.plugin.net.wooga.gradle:atlas-github:[2, 3['
 }
 
 pluginBundle {
@@ -71,3 +74,8 @@ gradlePlugin {
 github {
     repositoryName = "wooga/atlas-node-release"
 }
+
+cveHandler {
+    configurations("compileClasspath", "runtimeClasspath", "testCompileClasspath", "testRuntimeClasspath", "integrationTestCompileClasspath", "integrationTestRuntimeClasspath")
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,5 +31,11 @@ include 'shared'
 include 'api'
 include 'services:webservice'
 */
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
 
 rootProject.name = 'atlas-node-release'


### PR DESCRIPTION
## Decription

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin net.wooga.cve-dependency-resolution which applies overrides for dependencies with know fixes for security issues.

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
