### PR TITLE
Npmrc generation only executed if nedded

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginCredentialsSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginCredentialsSpec.groovy
@@ -158,7 +158,7 @@ class NodeReleasePluginCredentialsSpec extends GithubIntegrationSpec {
         result.wasExecuted(":ensureNpmrc")
     }
 
-    def "skips task of type NpmCredentialsTask with no set credentials"() {
+    def "skips task of type NpmCredentialsTask when no credentials set"() {
 
         given: "a valid defined task"
         buildFile << """                   

--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginEngineSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginEngineSpec.groovy
@@ -25,6 +25,9 @@ import spock.lang.Unroll
 
 class NodeReleasePluginEngineSpec extends GithubIntegrationSpec {
 
+    static def homeNpmRc = new File(System.getProperty("user.home"), ".npmrc")
+    static def tmpHomeNpmRc = new File(System.getProperty("user.home"), ".npmrc.tmp")
+
     @Shared
     def version = "1.0.0"
 
@@ -45,6 +48,7 @@ class NodeReleasePluginEngineSpec extends GithubIntegrationSpec {
     @Shared
     File packageJsonFile
 
+
     def setup() {
 
         environmentVariables.set("GRGIT_USER", testUserName)
@@ -64,14 +68,14 @@ class NodeReleasePluginEngineSpec extends GithubIntegrationSpec {
             group = 'test'
             version = "$version"
             ${applyPlugin(NodeReleasePlugin)}    
-            node.version = '10.5.0'
+            node.version = '18.7.0'
             node.download = true
         """.stripIndent()
 
         packageJsonFile = createFile('package.json')
         packageJsonFile.text = packageJsonContent([
                 "scripts"        : ["clean": "shx echo \"clean\"", "test": "shx echo \"test\"", "build": "shx echo \"build\""],
-                "devDependencies": ["shx": "^0.3.2"],
+                "devDependencies": ["shx": "^0.3.4"],
         ])
 
         git = Grgit.init(dir: projectDir)
@@ -87,9 +91,6 @@ class NodeReleasePluginEngineSpec extends GithubIntegrationSpec {
         if (lockfile) {
             createFile(lockfile)
         }
-
-        //and: "dependencies are installed"
-        //runTasksSuccessfully('npmSetup')
 
         when:
         "run task ${task}"

--- a/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/node/NodeReleasePluginPublishSpec.groovy
@@ -94,7 +94,7 @@ class NodeReleasePluginPublishSpec extends GithubIntegrationSpec {
             group = 'test'
             version = "$version"
             ${applyPlugin(NodeReleasePlugin)}    
-            node.version = '10.5.0'
+            node.version = '18.7.0'
             node.download = true
             
             github.repositoryName = '$testRepositoryName'


### PR DESCRIPTION
## Description

Most of times, especially on local machine execution, `ensureNpmrc` gets executed, even though there are no configured credentials on the gradle project, and a `~/.npmrc` file is available. Now `ensureNpmrc` only is executed if there is no `~/.npmrc` file and  there are available username, password and npm repository URL.


## Changes
* ![CHANGE] `ensureNpmrc` task only executed when credentials are available and there is no home .npmrc file.




[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
